### PR TITLE
Feat/webhook

### DIFF
--- a/marblerun-coordinator/templates/coordinator.yaml
+++ b/marblerun-coordinator/templates/coordinator.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: coordinator
     app.kubernetes.io/part-of: marblerun
-    app.kubernetes.io/version: {{ .Values.coordinator.coordinatorImageVersion }}
+    app.kubernetes.io/version: {{ .Values.global.image.version }}
     {{ .Values.global.coordinatorComponentLabel }}: coordinator
     {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
 spec:
@@ -44,8 +44,8 @@ spec:
           - name: OE_SIMULATION
             value: "{{ .Values.coordinator.simulation }}"
           name: coordinator
-          image: {{ .Values.coordinator.coordinatorImage }}:{{ .Values.coordinator.coordinatorImageVersion }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          image: "{{ .Values.global.image.repository }}/coordinator:{{ .Values.global.image.version }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           livenessProbe:
             httpGet:
               path: /status

--- a/marblerun-coordinator/templates/marble-injector.yaml
+++ b/marblerun-coordinator/templates/marble-injector.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: marble-injector
     app.kubernetes.io/part-of: marblerun
-    app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
+    app.kubernetes.io/version: {{ .Values.global.image.version }}
 spec:
   ports:
   - port: 443
@@ -23,20 +23,20 @@ metadata:
   labels:
     app.kubernetes.io/name: marble-injector
     app.kubernetes.io/part-of: marblerun
-    app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
+    app.kubernetes.io/version: {{ .Values.global.image.version }}
 spec:
   replicas: {{ .Values.webhook.webhookReplicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: marble-injector
       app.kubernetes.io/part-of: marblerun
-      app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
+      app.kubernetes.io/version: {{ .Values.global.image.version }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: marble-injector
         app.kubernetes.io/part-of: marblerun
-        app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
+        app.kubernetes.io/version: {{ .Values.global.image.version }}
         {{- with .Values.global.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       containers:
@@ -45,8 +45,8 @@ spec:
         - -tlsCertFile=/etc/webhook/certs/cert.pem
         - -tlsKeyFile=/etc/webhook/certs/key.pem
         name: marble-injector
-        image: {{ .Values.webhook.webhookImage }}:{{ .Values.webhook.webhookImageVersion }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        image: "{{ .Values.global.image.repository }}/marble-injector:{{ .Values.global.image.version }}"
+        imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         volumeMounts:
           - name: webhook-certs
             mountPath: /etc/webhook/certs
@@ -67,7 +67,7 @@ metadata:
   labels:
     app.kubernetes.io/name: marble-injector
     app.kubernetes.io/part-of: marblerun
-    app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }} 
+    app.kubernetes.io/version: {{ .Values.global.image.version }} 
 webhooks:
   - name: marble-injector.cluster.local
     clientConfig:

--- a/marblerun-coordinator/templates/webhook.yaml
+++ b/marblerun-coordinator/templates/webhook.yaml
@@ -4,14 +4,16 @@ kind: Service
 metadata:
   name: marble-injector
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: marble-injector
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
 spec:
   ports:
   - port: 443
     targetPort: 8443
   selector:
     app.kubernetes.io/name: marble-injector
-    app.kubernetes.io/part-of: marblerun
-    app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -22,19 +24,19 @@ metadata:
     app.kubernetes.io/name: marble-injector
     app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
-    {{ .Values.global.coordinatorComponentLabel }}: marble-injector
-    {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.webhook.webhookReplicas }}
   selector:
     matchLabels:
-      {{ .Values.global.coordinatorComponentLabel }}: marble-injector
-      {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
+      app.kubernetes.io/name: marble-injector
+      app.kubernetes.io/part-of: marblerun
+      app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
   template:
     metadata:
       labels:
-        {{ .Values.global.coordinatorComponentLabel }}: marble-injector
-        {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
+        app.kubernetes.io/name: marble-injector
+        app.kubernetes.io/part-of: marblerun
+        app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
         {{- with .Values.global.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       containers:
@@ -62,6 +64,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: marble-injector
+  labels:
+    app.kubernetes.io/name: marble-injector
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }} 
 webhooks:
   - name: marble-injector.cluster.local
     clientConfig:

--- a/marblerun-coordinator/templates/webhook.yaml
+++ b/marblerun-coordinator/templates/webhook.yaml
@@ -1,0 +1,103 @@
+{{ if .Values.webhook.start }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: marble-injector
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: marble-injector
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marble-injector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: marble-injector
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.webhook.webhookImageVersion }}
+    {{ .Values.global.coordinatorComponentLabel }}: marble-injector
+    {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.webhook.webhookReplicas }}
+  selector:
+    matchLabels:
+      {{ .Values.global.coordinatorComponentLabel }}: marble-injector
+      {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
+  template:
+    metadata:
+      labels:
+        {{ .Values.global.coordinatorComponentLabel }}: marble-injector
+        {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
+        {{- with .Values.global.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+    spec:
+      containers:
+      - args:
+        - -coordAddr=coordinator-mesh-api.{{ .Release.Namespace }}:{{ .Values.coordinator.meshServerPort }}
+        - -tlsCertFile=/etc/webhook/certs/cert.pem
+        - -tlsKeyFile=/etc/webhook/certs/key.pem
+        name: marble-injector
+        image: {{ .Values.webhook.webhookImage }}:{{ .Values.webhook.webhookImageVersion }}
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        volumeMounts:
+          - name: webhook-certs
+            mountPath: /etc/webhook/certs
+            readOnly: true
+        ports:
+          - containerPort: 8443
+            name: http
+
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: marble-injector-webhook-certs
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: marble-injector
+webhooks:
+  - name: marble-injector.cluster.local
+    clientConfig:
+      caBundle: {{ .Values.webhook.CABundle }}
+      service:
+        name: marble-injector
+        namespace: marblerun
+        path: "/mutate"
+    rules:
+    - operations: ["CREATE"]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      scope: "Namespaced"
+    namespaceSelector:
+      matchLabels:
+        marblerun/monitor: marblerun
+        marblerun/injectsgx: enabled
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+  - name: marble-injector-no-sgx.cluster.local
+    clientConfig:
+      caBundle: {{ .Values.webhook.CABundle }}
+      service:
+        name: marble-injector
+        namespace: marblerun
+        path: "/mutate-no-sgx"
+    rules:
+    - operations: ["CREATE"]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      scope: "Namespaced"
+    namespaceSelector:
+      matchLabels:
+        marblerun/monitor: marblerun
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+{{ end }}

--- a/marblerun-coordinator/values.yaml
+++ b/marblerun-coordinator/values.yaml
@@ -5,7 +5,10 @@
 
 # Values that are passed along to sub-charts
 global:
-  imagePullPolicy:  IfNotPresent
+  image:
+    pullPolicy: IfNotPresent
+    version: v0.2.0
+    repository: ghcr.io/edgelesssys
 
   # Additional annotations to add to all pods
   podAnnotations: {}
@@ -31,18 +34,14 @@ sgxDevice:
 
 
 # webhook configuration
-webhook:
+marbleInjector:
   start: false
-  webhookImage: ghcr.io/edgelesssys/webhook
-  webhookImageVersion: v0.1.0
-  webhookReplicas: 1
+  marbleInjectorReplicas: 1
   CABundle: "CA_Bundle_Base64"
 
 
 # coordinator configuration
 coordinator:
-  coordinatorImage: ghcr.io/edgelesssys/coordinator
-  coordinatorImageVersion: v0.2.0
   coordinatorReplicas: 1
 
   # Environment configuration for the coordinator control-plane

--- a/marblerun-coordinator/values.yaml
+++ b/marblerun-coordinator/values.yaml
@@ -30,6 +30,14 @@ sgxDevice:
   start: true
 
 
+# webhook configuration
+webhook:
+  start: false
+  webhookImage: ghcr.io/edgelesssys/webhook
+  webhookImageVersion: v0.1.0
+  webhookReplicas: 1
+  CABundle: {}
+
 
 # coordinator configuration
 coordinator:

--- a/marblerun-coordinator/values.yaml
+++ b/marblerun-coordinator/values.yaml
@@ -36,7 +36,7 @@ webhook:
   webhookImage: ghcr.io/edgelesssys/webhook
   webhookImageVersion: v0.1.0
   webhookReplicas: 1
-  CABundle: {}
+  CABundle: "CA_Bundle_Base64"
 
 
 # coordinator configuration


### PR DESCRIPTION
Adds the mutating webhook configuration to the marblerun helm chart.
The docker image of the webhook currently does not exist and needs to be created before this chart can be used