### PR TITLE
Change webhook namespace selector labels

### DIFF
--- a/marblerun-coordinator/templates/marble-injector.yaml
+++ b/marblerun-coordinator/templates/marble-injector.yaml
@@ -84,8 +84,8 @@ webhooks:
       scope: "Namespaced"
     namespaceSelector:
       matchLabels:
-        marblerun/monitor: marblerun
-        marblerun/injectsgx: enabled
+        marblerun/inject: enabled
+        marblerun/inject-sgx: enabled
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
   - name: marble-injector-no-sgx.cluster.local
@@ -103,7 +103,7 @@ webhooks:
       scope: "Namespaced"
     namespaceSelector:
       matchLabels:
-        marblerun/monitor: marblerun
+        marblerun/inject: marblerun
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 {{ end }}


### PR DESCRIPTION
Change labels monitored by the webhook to "marblerun/inject" and "marblerun/inject-sgx" to better reflect their purpose