### PR TITLE
Fix wrong label selector in mutating-webhook-configuration

### DIFF
--- a/marblerun-coordinator/templates/marble-injector.yaml
+++ b/marblerun-coordinator/templates/marble-injector.yaml
@@ -103,7 +103,7 @@ webhooks:
       scope: "Namespaced"
     namespaceSelector:
       matchLabels:
-        marblerun/inject: marblerun
+        marblerun/inject: enabled
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 {{ end }}


### PR DESCRIPTION
Namespace label selector should be "marblerun/inject: enabled", which was alread correct in the first webhook but was overlooked in the second one.