### PR TITLE
Increase epc from 10 Bytes to 10MiB

### DIFF
--- a/marblerun-coordinator/values.yaml
+++ b/marblerun-coordinator/values.yaml
@@ -55,7 +55,7 @@ coordinator:
   resources:
     limits:
       # Disable this if your running on a cluster with an SGX Device Plugin
-      sgx.intel.com/epc: 10
+      sgx.intel.com/epc: "10Mi"
 
   # Set the storage class for your cluster
   # storageClass:


### PR DESCRIPTION
The older azure plugin defined the values for EPC in MiB, the Intel plugin however uses [Kubernetes memory definitions](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory).
This causes the coordinator to only request 10 Bytes of EPC, this PR fixes that.