### PR TITLE
AB#1089 dcap configMap

### DIFF
--- a/marblerun-coordinator/templates/coordinator.yaml
+++ b/marblerun-coordinator/templates/coordinator.yaml
@@ -69,10 +69,16 @@ spec:
           volumeMounts:
           - name: coordinator-pv-storage
             mountPath: /coordinator/data
+          - name: dcap-conf
+            mountPath: /etc/sgx_default_qcnl.conf
+            subPath: sgx_default_qcnl.conf
       volumes:
         - name: coordinator-pv-storage
           persistentVolumeClaim:
             claimName: coordinator-pv-claim
+        - name: dcap-conf
+          configMap:
+            name: coordinator-dcap-config
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/marblerun-coordinator/templates/coordinator.yaml
+++ b/marblerun-coordinator/templates/coordinator.yaml
@@ -71,16 +71,20 @@ spec:
           volumeMounts:
           - name: coordinator-pv-storage
             mountPath: /coordinator/data
+          {{ if .Values.dcap }}
           - name: dcap-conf
             mountPath: /etc/sgx_default_qcnl.conf
             subPath: sgx_default_qcnl.conf
+          {{ end }}
       volumes:
         - name: coordinator-pv-storage
           persistentVolumeClaim:
             claimName: coordinator-pv-claim
+        {{ if .Values.dcap }}
         - name: dcap-conf
           configMap:
             name: coordinator-dcap-config
+        {{ end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/marblerun-coordinator/templates/coordinator.yaml
+++ b/marblerun-coordinator/templates/coordinator.yaml
@@ -43,6 +43,8 @@ spec:
             value: "{{ .Values.coordinator.sealDir }}"
           - name: OE_SIMULATION
             value: "{{ .Values.coordinator.simulation }}"
+          - name: DCAP_LIBRARY
+            value: "{{ .Values.coordinator.dcapQpl }}"
           name: coordinator
           image: "{{ .Values.global.image.repository }}/coordinator:{{ .Values.global.image.version }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}

--- a/marblerun-coordinator/templates/sgx_qcnl.yaml
+++ b/marblerun-coordinator/templates/sgx_qcnl.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.dcap }}
-apiVersion: 1
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: coordinator-dcap-config

--- a/marblerun-coordinator/templates/sgx_qcnl.yaml
+++ b/marblerun-coordinator/templates/sgx_qcnl.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.dcap }}
 apiVersion: 1
 kind: ConfigMap
 metadata:
@@ -13,3 +14,4 @@ data:
   sgx_default_qcnl.conf: |
     PCCS_URL={{ .Values.dcap.pccsUrl }}
     USE_SECURE_CERT={{ .Values.dcap.useSecureCert }}
+{{ end }}

--- a/marblerun-coordinator/templates/sgx_qcnl.yaml
+++ b/marblerun-coordinator/templates/sgx_qcnl.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+kind: ConfigMap
+metadata:
+  name: coordinator-dcap-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.global.image.version }}
+    {{ .Values.global.coordinatorComponentLabel }}: dcap-config
+    {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
+    {{- with .Values.global.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+data:
+  sgx_default_qcnl.conf: |
+    PCCS_URL={{ .Values.dcap.pccsUrl }}
+    USE_SECURE_CERT={{ .Values.dcap.useSecureCert }}

--- a/marblerun-coordinator/values.yaml
+++ b/marblerun-coordinator/values.yaml
@@ -51,6 +51,8 @@ coordinator:
   sealDir: "/coordinator/data/"
   # OE_SIMULATION needs be set to "1" when running on systems without SGX1+FLC capabilities
   simulation: "0"
+  # DCAP_LIBRARY needs to be "intel" if the libsgx-dcap-default-qpl is to be used, otherwise az-dcap-client is used by default
+  dcapQpl: "azure"
 
   resources:
     limits:
@@ -76,4 +78,4 @@ nodeSelector:
 # DCAP configuration settings
 dcap:
   pccsUrl: "https://localhost:8081/sgx/certification/v3/"
-  useSecureCert: "FALSE"
+  useSecureCert: "TRUE"

--- a/marblerun-coordinator/values.yaml
+++ b/marblerun-coordinator/values.yaml
@@ -72,3 +72,8 @@ tolerations:
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector.
 nodeSelector:
   beta.kubernetes.io/os: linux
+
+# DCAP configuration settings
+dcap:
+  pccsUrl: "https://localhost:8081/sgx/certification/v3/"
+  useSecureCert: "FALSE"


### PR DESCRIPTION
Adds a configMap to the helm chart containing the configuration file required by the default intel quote provider library.

If `dcap` is set to null during installation, no configMap is created and the coordinator deployment gets its configMap volume removed.
Additionally a new env variable `DCAP_LIBRARY` is added to the coordinator deployment to allow usage of the startup script introduced in https://github.com/edgelesssys/marblerun/pull/221