### PR TITLE
AB#1008 Refactor labels and resources

### DIFF
--- a/marblerun-coordinator/templates/coordinator.yaml
+++ b/marblerun-coordinator/templates/coordinator.yaml
@@ -5,8 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: coordinator
+    app.kubernetes.io/component: coordinator
     app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.global.image.version }}
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     {{ .Values.global.coordinatorComponentLabel }}: coordinator
     {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
 spec:
@@ -18,6 +20,11 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: coordinator
+        app.kubernetes.io/component: coordinator
+        app.kubernetes.io/part-of: marblerun
+        app.kubernetes.io/version: {{ .Values.global.image.version }}
+        app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
         {{ .Values.global.coordinatorComponentLabel }}: coordinator
         {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
         {{- with .Values.global.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
@@ -83,7 +90,7 @@ spec:
         {{ if .Values.dcap }}
         - name: dcap-conf
           configMap:
-            name: coordinator-dcap-config
+            name: sgx-qcnl
         {{ end }}
 ---
 apiVersion: v1
@@ -91,6 +98,12 @@ kind: PersistentVolumeClaim
 metadata:
   name: coordinator-pv-claim
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: coordinator-pv-claim
+    app.kubernetes.io/component: persistent-storage
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.global.image.version }}
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
 spec:
   {{- with .Values.coordinator.storageClass }}
   storageClassName: {{ .Values.coordinator.storageClass }}
@@ -106,6 +119,12 @@ kind: Service
 metadata:
   name: coordinator-client-api
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: coordinator-client-api
+    app.kubernetes.io/component: client-api
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.global.image.version }}
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
 spec:
   type: LoadBalancer
   selector:
@@ -121,6 +140,12 @@ kind: Service
 metadata:
   name: coordinator-mesh-api
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: coordinator-mesh-api
+    app.kubernetes.io/component: mesh-api
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.global.image.version }}
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
 spec:
   type: ClusterIP
   selector:

--- a/marblerun-coordinator/templates/marble-injector.yaml
+++ b/marblerun-coordinator/templates/marble-injector.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: marble-injector
+    app.kubernetes.io/component: admission-controller-svc
     app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.global.image.version }}
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
 spec:
   ports:
   - port: 443
@@ -22,8 +24,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: marble-injector
+    app.kubernetes.io/component: admission-controller
     app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.global.image.version }}
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
+    {{ .Values.global.coordinatorComponentLabel }}: admission-controller
+    {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.marbleInjector.marbleInjectorReplicas }}
   selector:
@@ -35,8 +41,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: marble-injector
+        app.kubernetes.io/component: admission-controller
         app.kubernetes.io/part-of: marblerun
         app.kubernetes.io/version: {{ .Values.global.image.version }}
+        app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
+        {{ .Values.global.coordinatorComponentLabel }}: admission-controller
+        {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
         {{- with .Values.global.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       containers:
@@ -55,6 +65,13 @@ spec:
         ports:
           - containerPort: 8443
             name: http
+        resources:
+          requests:
+            memory: "5Mi"
+            cpu: "1m"
+          limits:
+            memory: "15Mi"
+            cpu: "10m"
 
       volumes:
       - name: webhook-certs
@@ -67,8 +84,10 @@ metadata:
   name: marble-injector
   labels:
     app.kubernetes.io/name: marble-injector
+    app.kubernetes.io/component: admission-controller-configuration
     app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.global.image.version }}
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
 webhooks:
   - name: marble-injector.cluster.local
     clientConfig:

--- a/marblerun-coordinator/templates/serviceaccount.yaml
+++ b/marblerun-coordinator/templates/serviceaccount.yaml
@@ -4,6 +4,11 @@ metadata:
   name: marblerun-coordinator
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: marblerun-coordinator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.global.image.version }}
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     {{ .Values.global.coordinatorComponentLabel }}: controller
     {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
 {{- if .Values.global.pullSecret }}

--- a/marblerun-coordinator/templates/sgx-qcnl.yaml
+++ b/marblerun-coordinator/templates/sgx-qcnl.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coordinator-dcap-config
+  name: sgx-qcnl
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: sgx-qcnl
+    app.kubernetes.io/component: dcap-config
     app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.global.image.version }}
-    {{ .Values.global.coordinatorComponentLabel }}: dcap-config
-    {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
-    {{- with .Values.global.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
 data:
   sgx_default_qcnl.conf: |
     PCCS_URL={{ .Values.dcap.pccsUrl }}

--- a/marblerun-coordinator/values.yaml
+++ b/marblerun-coordinator/values.yaml
@@ -16,6 +16,8 @@ global:
   # Additional labels to add to all pods
   podLabels: {}
 
+  createdBy: Helm
+
   # control plane labels
   coordinatorComponentLabel: edgeless.systems/control-plane-component
   coordinatorNamespaceLabel: edgeless.systems/control-plane-ns
@@ -55,8 +57,12 @@ coordinator:
   dcapQpl: "azure"
 
   resources:
+    requests:
+      memory: "120Mi"
+      cpu: "10m"
     limits:
-      # Disable this if your running on a cluster with an SGX Device Plugin
+      cpu: "100m"
+      # Disable this if your running on a cluster without an SGX Device Plugin
       sgx.intel.com/epc: "10Mi"
 
   # Set the storage class for your cluster


### PR DESCRIPTION
Currently we are only using some of the recommended Kubernetes labels, and if we do, only for some resources.

This PR aims to fix this by adding the missing labels to pods, services etc.
I have also gone ahead and added some preliminary resource requests and limits for the Coordinator and marble-injector.

None of this is final and remains open to discussion.