### PR TITLE
Add annotations for OSM

### DIFF
--- a/marblerun-coordinator/templates/coordinator.yaml
+++ b/marblerun-coordinator/templates/coordinator.yaml
@@ -65,7 +65,6 @@ spec:
               name: http
             - containerPort: {{ .Values.coordinator.meshServerPort }}
               name: grcp
-
           resources:
           {{- toYaml .Values.coordinator.resources | nindent 12 }}
           volumeMounts:
@@ -130,3 +129,4 @@ spec:
   - name: grcp
     port: {{ .Values.coordinator.meshServerPort }}
     targetPort: {{ .Values.coordinator.meshServerPort }}
+    appProtocol: tcp

--- a/marblerun-coordinator/templates/marble-injector.yaml
+++ b/marblerun-coordinator/templates/marble-injector.yaml
@@ -38,6 +38,8 @@ spec:
         app.kubernetes.io/part-of: marblerun
         app.kubernetes.io/version: {{ .Values.global.image.version }}
         {{- with .Values.global.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+      annotations:
+        openservicemesh.io/sidecar-injection: disabled
     spec:
       containers:
       - args:


### PR DESCRIPTION
Add annotations for better integration with OpenServiceMesh:

* Add `openservicemesh.io/sidecar-injection: disabled` to Marble-Injector annotations to avoid unnecessary sidecar injection
* Add `appProtocol: tcp` to coordinator service spec so traffic is properly forwarded