### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ helm repo update
 
 ## MarbleRun
 
-[edgeless/marblerun-coordinator](https://github.com/edgelesssys/marblerun/tree/master/charts)
+[edgeless/marblerun](https://github.com/edgelesssys/marblerun/tree/master/charts)
 
 ```sh
-helm install marblerun edgeless/marblerun-coordinator \
+helm install marblerun edgeless/marblerun \
     --create-namespace \
     -n marblerun
 ```

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ helm install marblerun edgeless/marblerun \
 ```sh
 helm install edgelessdb edgeless/edgelessdb \
     --create-namespace \
-    -n marblerun
+    -n edb
 ```

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ helm install edgelessdb edgeless/edgelessdb \
     --create-namespace \
     -n edb
 ```
+
+## Constellation S3 proxy
+
+[edgeless/s3proxy](https://github.com/edgelesssys/constellation/tree/main/s3proxy/deploy/s3proxy)
+
+```sh
+helm install s3proxy edgeless/s3proxy \
+    --create-namespace \
+    -n s3proxy \
+    --set awsAccessKeyID="$ACCESS_KEY" \
+    --set awsSecretAccessKey="$ACCESS_SECRET"
+```


### PR DESCRIPTION
* MarbleRun instructions in the repo readme were still using the outdated chart from 2 years ago, lets fix that
* EdgelessDB instructions now no longer deploy to the marblerun namespace
* S3Proxy is now mentioned in README